### PR TITLE
bugfix: correctly execute updates with falsey values

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -62,13 +62,13 @@ exports.store = function(client, storeName, options) {
         var fieldName = _str.camelize(colName),
         val = data[fieldName];
 
-        if (!val && isPartialUpdate) {
+        if (_.isUndefined(val) && isPartialUpdate) {
           return;
         }
 
         colNames.push(colName);
 
-        if (!val) {
+        if (_.isUndefined(val)) {
           colVals.push(col.columnDefault ? 'DEFAULT' : 'NULL');
           return;
         }

--- a/test/test_simple_store.js
+++ b/test/test_simple_store.js
@@ -126,6 +126,27 @@ suite('Store', function() {
 
   });
 
+  test('Falsey updates are correctly applied', function() {
+    var store;
+    return layout.addStore('bigBiz.emp', {
+      columns: {
+        isHappy: 'boolean NOT NULL DEFAULT true',
+        footnote: 'text',
+      }
+    })
+    .then(function() {
+      store = client.store('bigBiz.emp');
+      return store.insert({
+        isHappy: false,
+        footnote: ''
+      });
+    })
+    .then(function(result) {
+      expect(result).to.have.property('isHappy', false);
+      expect(result).to.have.property('footnote', '');
+    });
+  });
+
   test('Adding a store twice ends in error', function() {
     return layout.addStore('bigBiz.emp', {
       columns: {


### PR DESCRIPTION
This was causing me trouble when implementing email verification. Tracked it down to a simple mistake in how val is treated in this loop. Take a look @aaronyo 
